### PR TITLE
Add adjustable font size

### DIFF
--- a/Enchanted/Extensions/FontScale+Extension.swift
+++ b/Enchanted/Extensions/FontScale+Extension.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+private struct FontScaleKey: EnvironmentKey {
+    static let defaultValue: CGFloat = 1.0
+}
+
+extension EnvironmentValues {
+    var fontScale: CGFloat {
+        get { self[FontScaleKey.self] }
+        set { self[FontScaleKey.self] = newValue }
+    }
+}
+
+struct ScaledFontModifier: ViewModifier {
+    @Environment(\.fontScale) private var fontScale
+    var size: CGFloat
+    var weight: Font.Weight = .regular
+    var design: Font.Design = .default
+
+    func body(content: Content) -> some View {
+        content.font(.system(size: size * fontScale, weight: weight, design: design))
+    }
+}
+
+extension View {
+    func scaledFont(size: CGFloat, weight: Font.Weight = .regular, design: Font.Design = .default) -> some View {
+        self.modifier(ScaledFontModifier(size: size, weight: weight, design: design))
+    }
+}

--- a/Enchanted/Models/AppFontSize.swift
+++ b/Enchanted/Models/AppFontSize.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// App font size preference.
+enum AppFontSize: String, Identifiable, CaseIterable {
+    case small, normal, large
+
+    var id: String { rawValue }
+
+    /// Human readable description
+    var toString: String {
+        switch self {
+        case .small: return "Small"
+        case .normal: return "Normal"
+        case .large: return "Large"
+        }
+    }
+
+    /// Scale factor applied to base font sizes
+    var scale: CGFloat {
+        switch self {
+        case .small: return 0.9
+        case .normal: return 1.0
+        case .large: return 1.1
+        }
+    }
+}

--- a/Enchanted/UI/Shared/ApplicationEntry.swift
+++ b/Enchanted/UI/Shared/ApplicationEntry.swift
@@ -10,6 +10,7 @@ import SwiftData
 
 struct ApplicationEntry: View {
     @AppStorage("colorScheme") private var colorScheme: AppColorScheme = .system
+    @AppStorage("fontSize") private var fontSize: AppFontSize = .normal
     @State private var languageModelStore = LanguageModelStore.shared
     @State private var conversationStore = ConversationStore.shared
     @State private var completionsStore = CompletionsStore.shared
@@ -47,6 +48,7 @@ struct ApplicationEntry: View {
             }
         }
         .preferredColorScheme(colorScheme.toiOSFormat)
+        .environment(\.fontScale, fontSize.scale)
     }
 }
 

--- a/Enchanted/UI/Shared/Chat/Components/ChatMessages/CodeBlockView.swift
+++ b/Enchanted/UI/Shared/Chat/Components/ChatMessages/CodeBlockView.swift
@@ -19,7 +19,7 @@ struct CodeBlockView: View {
         VStack(spacing: 0) {
             HStack {
                 Text(language)
-                    .font(.system(size: 13, design: .monospaced))
+                    .scaledFont(size: 13, design: .monospaced)
                     .fontWeight(.semibold)
                 Spacer()
                 

--- a/Enchanted/UI/Shared/Chat/Components/ConversationStatusView.swift
+++ b/Enchanted/UI/Shared/Chat/Components/ConversationStatusView.swift
@@ -17,7 +17,7 @@ struct ConversationStatusView: View {
         case .error(let message): HStack {
             Text(message)
                 .foregroundColor(.red)
-                .font(.system(size: 16))
+                .scaledFont(size: 16)
             Spacer()
         }
         }

--- a/Enchanted/UI/Shared/Chat/Components/EmptyConversaitonView.swift
+++ b/Enchanted/UI/Shared/Chat/Components/EmptyConversaitonView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct EmptyConversaitonView: View, KeyboardReadable {
     @Environment(\.openURL) private var openURL
+    @Environment(\.fontScale) private var fontScale
     @State var showPromptsAnimation = false
     @State var prompts: [SamplePrompts] = []
     var sendPrompt: (String) -> ()
@@ -37,7 +38,7 @@ struct EmptyConversaitonView: View, KeyboardReadable {
             VStack(spacing: 25) {
                 VStack(alignment: .center) {
                     Text("Enchanted")
-                        .font(Font.system(size: 46, weight: .thin))
+                        .font(Font.system(size: 46 * fontScale, weight: .thin))
                         .multilineTextAlignment(.center)
                         .foregroundStyle(
                             LinearGradient(
@@ -70,7 +71,7 @@ struct EmptyConversaitonView: View, KeyboardReadable {
                         }) {
                             VStack(alignment: .leading) {
                                 Text(prompts[index].prompt)
-                                    .font(.system(size: 15))
+                                    .scaledFont(size: 15)
                                 Spacer()
                                 
                                 HStack {

--- a/Enchanted/UI/Shared/Chat/Components/Header.swift
+++ b/Enchanted/UI/Shared/Chat/Components/Header.swift
@@ -23,7 +23,7 @@ struct Header: View {
                 Spacer()
                 
                 Text(selectedModel.name)
-                    .font(.system(size: 15))
+                    .scaledFont(size: 15)
                     .fontWeight(.medium)
                 
                 Spacer()

--- a/Enchanted/UI/Shared/Chat/Components/ReadingAloudView.swift
+++ b/Enchanted/UI/Shared/Chat/Components/ReadingAloudView.swift
@@ -20,13 +20,13 @@ struct ReadingAloudView: View {
                 .frame(width: 18)
             
             Text("Reading Aloud")
-                .font(.system(size: 14))
+                .scaledFont(size: 14)
             
             Spacer()
             
             Button(action: onStopTap) {
                 Image(systemName: "stop.fill")
-                    .font(.system(size: 15, weight: .semibold))
+                    .scaledFont(size: 15, weight: .semibold)
                     .padding(5)
             }
             .buttonStyle(GrowingButton())

--- a/Enchanted/UI/Shared/Chat/Components/UnreachableAPIView.swift
+++ b/Enchanted/UI/Shared/Chat/Components/UnreachableAPIView.swift
@@ -18,7 +18,7 @@ struct UnreachableAPIView: View {
                     .lineLimit(nil)
                     .minimumScaleFactor(0.5)
                     .fontWeight(.medium)
-                    .font(.system(size: 14))
+                    .scaledFont(size: 14)
             }
             
             Spacer()

--- a/Enchanted/UI/Shared/Settings/Settings.swift
+++ b/Enchanted/UI/Shared/Settings/Settings.swift
@@ -17,6 +17,7 @@ struct Settings: View {
     @AppStorage("systemPrompt") private var systemPrompt: String = ""
     @AppStorage("vibrations") private var vibrations: Bool = true
     @AppStorage("colorScheme") private var colorScheme = AppColorScheme.system
+    @AppStorage("fontSize") private var fontSize: AppFontSize = .normal
     @AppStorage("defaultOllamaModel") private var defaultOllamaModel: String = ""
     @AppStorage("ollamaBearerToken") private var ollamaBearerToken: String = ""
     @AppStorage("appUserInitials") private var appUserInitials: String = ""
@@ -68,7 +69,8 @@ struct Settings: View {
             systemPrompt: $systemPrompt, 
             vibrations: $vibrations,
             colorScheme: $colorScheme,
-            defaultOllamModel: $defaultOllamaModel, 
+            fontSize: $fontSize,
+            defaultOllamModel: $defaultOllamaModel,
             ollamaBearerToken: $ollamaBearerToken,
             appUserInitials: $appUserInitials,
             pingInterval: $pingInterval,

--- a/Enchanted/UI/Shared/Settings/SettingsView.swift
+++ b/Enchanted/UI/Shared/Settings/SettingsView.swift
@@ -19,6 +19,7 @@ struct SettingsView: View {
     @Binding var appUserInitials: String
     @Binding var pingInterval: String
     @Binding var voiceIdentifier: String
+    @Binding var fontSize: AppFontSize
     @State var ollamaStatus: Bool?
     var save: () -> ()
     var checkServer: () -> ()
@@ -36,7 +37,7 @@ struct SettingsView: View {
                         presentationMode.wrappedValue.dismiss()
                     } label: {
                         Text("Cancel")
-                            .font(.system(size: 16))
+                            .scaledFont(size: 16)
                             .foregroundStyle(Color(.label))
                     }
                     
@@ -45,7 +46,7 @@ struct SettingsView: View {
                     
                     Button(action: save) {
                         Text("Save")
-                            .font(.system(size: 16))
+                            .scaledFont(size: 16)
                             .foregroundStyle(Color(.label))
                     }
                 }
@@ -53,7 +54,7 @@ struct SettingsView: View {
                 HStack {
                     Spacer()
                     Text("Settings")
-                        .font(.system(size: 16))
+                        .scaledFont(size: 16)
                         .fontWeight(.medium)
                         .foregroundStyle(Color(.label))
                     Spacer()
@@ -77,7 +78,7 @@ struct SettingsView: View {
                     VStack(alignment: .leading) {
                         Text("System prompt")
                         TextEditor(text: $systemPrompt)
-                            .font(.system(size: 13))
+                            .scaledFont(size: 13)
                             .cornerRadius(4)
                             .multilineTextAlignment(.leading)
                             .frame(minHeight: 100)
@@ -128,6 +129,15 @@ struct SettingsView: View {
                         }
                     } label: {
                         Label("Appearance", systemImage: "sun.max")
+                            .foregroundStyle(Color.label)
+                    }
+
+                    Picker(selection: $fontSize) {
+                        ForEach(AppFontSize.allCases, id:\.self) { size in
+                            Text(size.toString).tag(size)
+                        }
+                    } label: {
+                        Label("Font Size", systemImage: "textformat.size")
                             .foregroundStyle(Color.label)
                     }
                     
@@ -209,6 +219,7 @@ struct SettingsView: View {
         appUserInitials: .constant("AM"),
         pingInterval: .constant("5"),
         voiceIdentifier: .constant("sample"),
+        fontSize: .constant(.normal),
         save: {},
         checkServer: {},
         deleteAll: {},

--- a/Enchanted/UI/Shared/Sidebar/Components/ConversationHistoryListView.swift
+++ b/Enchanted/UI/Shared/Sidebar/Components/ConversationHistoryListView.swift
@@ -48,7 +48,7 @@ struct ConversationHistoryList: View {
                 
                 HStack {
                     Text(conversationGroup.date.daysAgoString())
-                        .font(.system(size: 14))
+                        .scaledFont(size: 14)
                         .fontWeight(.semibold)
                         .foregroundColor(Color(.systemGray))
                     
@@ -71,7 +71,7 @@ struct ConversationHistoryList: View {
                             
                             Text(dailyConversation.name)
                                 .lineLimit(1)
-                                .font(.system(size: 16))
+                                .scaledFont(size: 16)
                                 .foregroundColor(Color(.label))
                                 .animation(.easeOut(duration: 0.15))
                                 .transition(.opacity)

--- a/Enchanted/UI/Shared/Sidebar/Components/SidebarButton.swift
+++ b/Enchanted/UI/Shared/Sidebar/Components/SidebarButton.swift
@@ -22,7 +22,7 @@ struct SidebarButton: View {
                 
                 Text(title)
                     .lineLimit(1)
-                    .font(.system(size: 14))
+                    .scaledFont(size: 14)
                     .fontWeight(.regular)
                 
                 Spacer()

--- a/Enchanted/UI/iOS/ChatView_iOS.swift
+++ b/Enchanted/UI/iOS/ChatView_iOS.swift
@@ -144,7 +144,7 @@ struct ChatView: View {
                 TextField("Message", text: $message, axis: .vertical)
                     .focused($isFocusedInput)
                     .frame(minHeight: 40)
-                    .font(.system(size: 14))
+                    .scaledFont(size: 14)
                 
                 RecordingView(speechRecognizer: speechRecognizer, isRecording: $isRecording.animation()) { transcription in
                     self.message = transcription

--- a/Enchanted/UI/iOS/Components/SelectTextSheet.swift
+++ b/Enchanted/UI/iOS/Components/SelectTextSheet.swift
@@ -18,7 +18,7 @@ struct SelectTextSheet: View {
         VStack {
             ZStack {
                 Text("Select Text")
-                    .font(.system(size: 16))
+                    .scaledFont(size: 16)
                     .fontWeight(.bold)
                 
                 HStack {

--- a/Enchanted/UI/macOS/Chat/Components/InputFields_macOS.swift
+++ b/Enchanted/UI/macOS/Chat/Components/InputFields_macOS.swift
@@ -71,7 +71,7 @@ struct InputFieldsView: View {
             ZStack(alignment: .trailing) {
                 TextField("Message", text: $message.animation(.easeOut(duration: 0.3)), axis: .vertical)
                     .focused($isFocusedInput)
-                    .font(.system(size: 14))
+                    .scaledFont(size: 14)
                     .frame(maxWidth:.infinity, minHeight: 40)
                     .clipped()
                     .textFieldStyle(.plain)

--- a/Enchanted/UI/macOS/Components/CompletionButtonView.swift
+++ b/Enchanted/UI/macOS/Components/CompletionButtonView.swift
@@ -20,10 +20,10 @@ struct CompletionButtonView: View {
                     .padding(EdgeInsets(top: 4, leading: 8, bottom: 4, trailing: 8))
                     .background(Color.gray.opacity(0.2))
                     .cornerRadius(5)
-                    .font(.system(size: 10, weight: .medium, design: .default))
+                    .scaledFont(size: 10, weight: .medium)
                 
                 Text(name)
-                    .font(.system(size: 12))
+                    .scaledFont(size: 12)
             }
             .padding(.vertical, 4)
             .padding(.horizontal, 8)

--- a/Enchanted/UI/macOS/Components/CompletionPanelView.swift
+++ b/Enchanted/UI/macOS/Components/CompletionPanelView.swift
@@ -75,7 +75,7 @@ struct PanelCompletionsView: View {
                     .padding(EdgeInsets(top: 4, leading: 8, bottom: 4, trailing: 8))
                     .background(Color.gray.opacity(0.2))
                     .cornerRadius(5)
-                    .font(.system(size: 10, weight: .medium, design: .default))
+                    .scaledFont(size: 10, weight: .medium)
                 
                 Text("Your Command")
                     .enchantify()
@@ -103,7 +103,7 @@ struct PanelCompletionsView: View {
                     .padding(EdgeInsets(top: 4, leading: 8, bottom: 4, trailing: 8))
                     .background(Color.gray.opacity(0.2))
                     .cornerRadius(5)
-                    .font(.system(size: 10, weight: .medium, design: .default))
+                    .scaledFont(size: 10, weight: .medium)
             }
             .buttonStyle(GrowingButton())
             .keyboardShortcut(.tab, modifiers: [])

--- a/Enchanted/UI/macOS/Components/DragAndDrop.swift
+++ b/Enchanted/UI/macOS/Components/DragAndDrop.swift
@@ -16,7 +16,7 @@ struct DragAndDrop: View {
             
             HStack(spacing: 8) {
                 Image(systemName: "photo")
-                    .font(.system(size: 25))
+                    .scaledFont(size: 25)
                 Text("Drop your image here")
                     .font(.title2)
             }


### PR DESCRIPTION
## Summary
- add `AppFontSize` model to represent font scaling option
- provide `fontScale` environment value and `scaledFont` modifier
- expose font size choice in Settings
- apply font scaling across UI components

## Testing
- `swift build` *(fails: Could not find Package.swift)*