### PR TITLE
feat: Add configurable font sizes for accessibility

### DIFF
--- a/Enchanted/Models/FontConfiguration.swift
+++ b/Enchanted/Models/FontConfiguration.swift
@@ -1,0 +1,88 @@
+//
+//  FontConfiguration.swift
+//  Enchanted
+//
+//  Created by Claude on 24/05/2025.
+//
+
+import SwiftUI
+
+enum FontSizeCategory: String, CaseIterable {
+    case extraSmall = "extraSmall"
+    case small = "small"
+    case medium = "medium"
+    case large = "large"
+    case extraLarge = "extraLarge"
+    
+    var displayName: String {
+        switch self {
+        case .extraSmall: return "Extra Small"
+        case .small: return "Small"
+        case .medium: return "Medium"
+        case .large: return "Large"
+        case .extraLarge: return "Extra Large"
+        }
+    }
+    
+    var baseSize: CGFloat {
+        switch self {
+        case .extraSmall: return 12
+        case .small: return 13
+        case .medium: return 14
+        case .large: return 16
+        case .extraLarge: return 18
+        }
+    }
+    
+    var scaleFactor: CGFloat {
+        return baseSize / FontSizeCategory.medium.baseSize
+    }
+}
+
+struct FontConfiguration {
+    let sizeCategory: FontSizeCategory
+    
+    init(sizeCategory: FontSizeCategory = .medium) {
+        self.sizeCategory = sizeCategory
+    }
+    
+    // UI Font sizes with proportional scaling
+    var smallUIFont: CGFloat { 12 * sizeCategory.scaleFactor }
+    var regularUIFont: CGFloat { 14 * sizeCategory.scaleFactor }
+    var mediumUIFont: CGFloat { 16 * sizeCategory.scaleFactor }
+    
+    // Chat and content font sizes
+    var chatInputFont: CGFloat { 14 * sizeCategory.scaleFactor }
+    var systemPromptFont: CGFloat { 13 * sizeCategory.scaleFactor }
+    var codeFont: CGFloat { 13 * sizeCategory.scaleFactor }
+    
+    // Markdown base font size for theme
+    var markdownBaseSize: CGFloat { 14 * sizeCategory.scaleFactor }
+}
+
+// Extension to provide SwiftUI Font objects
+extension FontConfiguration {
+    func smallUIFont(design: Font.Design = .default) -> Font {
+        .system(size: smallUIFont, design: design)
+    }
+    
+    func regularUIFont(design: Font.Design = .default) -> Font {
+        .system(size: regularUIFont, design: design)
+    }
+    
+    func mediumUIFont(design: Font.Design = .default) -> Font {
+        .system(size: mediumUIFont, design: design)
+    }
+    
+    func chatInputFont(design: Font.Design = .default) -> Font {
+        .system(size: chatInputFont, design: design)
+    }
+    
+    func systemPromptFont(design: Font.Design = .default) -> Font {
+        .system(size: systemPromptFont, design: design)
+    }
+    
+    func codeFont(design: Font.Design = .monospaced) -> Font {
+        .system(size: codeFont, design: design)
+    }
+}

--- a/Enchanted/Stores/FontConfigurationStore.swift
+++ b/Enchanted/Stores/FontConfigurationStore.swift
@@ -1,0 +1,31 @@
+//
+//  FontConfigurationStore.swift
+//  Enchanted
+//
+//  Created by Claude on 24/05/2025.
+//
+
+import SwiftUI
+import Combine
+
+class FontConfigurationStore: ObservableObject {
+    static let shared = FontConfigurationStore()
+    
+    @Published var fontConfiguration: FontConfiguration
+    
+    @AppStorage("fontSizeCategory") private var fontSizeCategoryRawValue: String = FontSizeCategory.medium.rawValue
+    
+    private init() {
+        let category = FontSizeCategory(rawValue: fontSizeCategoryRawValue) ?? .medium
+        self.fontConfiguration = FontConfiguration(sizeCategory: category)
+    }
+    
+    func updateFontSize(category: FontSizeCategory) {
+        fontSizeCategoryRawValue = category.rawValue
+        fontConfiguration = FontConfiguration(sizeCategory: category)
+    }
+    
+    var currentSizeCategory: FontSizeCategory {
+        fontConfiguration.sizeCategory
+    }
+}

--- a/Enchanted/UI/Shared/Chat/Components/ChatMessages/ChatMessageView.swift
+++ b/Enchanted/UI/Shared/Chat/Components/ChatMessages/ChatMessageView.swift
@@ -13,6 +13,7 @@ import Splash
 struct ChatMessageView: View {
     @Environment(\.colorScheme) var colorScheme
     @StateObject private var speechSynthesizer = SpeechSynthesizer.shared
+    @StateObject private var fontConfigurationStore = FontConfigurationStore.shared
     var message: MessageSD
     var showLoader: Bool = false
     var userInitials: String
@@ -73,7 +74,7 @@ struct ChatMessageView: View {
                                         .textSelection(.enabled)
 #endif
                                         .markdownCodeSyntaxHighlighter(.splash(theme: codeHighlightColorScheme))
-                                        .markdownTheme(MarkdownColours.enchantedTheme)
+                                        .markdownTheme(MarkdownColours.enchantedTheme(fontSize: fontConfigurationStore.fontConfiguration.markdownBaseSize))
                                 }
                             } else {
                                 if message.thinkComplete {
@@ -94,7 +95,7 @@ struct ChatMessageView: View {
                             .textSelection(.enabled)
     #endif
                             .markdownCodeSyntaxHighlighter(.splash(theme: codeHighlightColorScheme))
-                            .markdownTheme(MarkdownColours.enchantedTheme)
+                            .markdownTheme(MarkdownColours.enchantedTheme(fontSize: fontConfigurationStore.fontConfiguration.markdownBaseSize))
                     }
                     
                     if let uiImage = image {

--- a/Enchanted/UI/Shared/Chat/Components/ChatMessages/CodeBlockView.swift
+++ b/Enchanted/UI/Shared/Chat/Components/ChatMessages/CodeBlockView.swift
@@ -10,6 +10,8 @@ import MarkdownUI
 
 struct CodeBlockView: View {
     var configuration: CodeBlockConfiguration
+    @StateObject private var fontConfigurationStore = FontConfigurationStore.shared
+    
     var language: String {
         let language = configuration.language ?? "code"
         return language != "" ? language : "code"
@@ -19,7 +21,7 @@ struct CodeBlockView: View {
         VStack(spacing: 0) {
             HStack {
                 Text(language)
-                    .font(.system(size: 13, design: .monospaced))
+                    .font(fontConfigurationStore.fontConfiguration.codeFont())
                     .fontWeight(.semibold)
                 Spacer()
                 

--- a/Enchanted/UI/Shared/Chat/Components/ChatMessages/MarkdownColours.swift
+++ b/Enchanted/UI/Shared/Chat/Components/ChatMessages/MarkdownColours.swift
@@ -36,10 +36,11 @@ struct MarkdownColours {
     static let checkbox = Color(rgba: 0xb9b9_bbff)
     static let checkboxBackground = Color(rgba: 0xeeee_efff)
     
-    static let enchantedTheme = Theme()
-        .text {
-            FontSize(14)
-        }
+    static func enchantedTheme(fontSize: CGFloat = 14) -> Theme {
+        return Theme()
+            .text {
+                FontSize(fontSize)
+            }
         .code {
             FontFamilyVariant(.monospaced)
             FontSize(.em(0.85))
@@ -172,4 +173,5 @@ struct MarkdownColours {
                 .overlay(border)
                 .markdownMargin(top: 24, bottom: 24)
         }
+    }
 }

--- a/Enchanted/UI/Shared/Settings/Settings.swift
+++ b/Enchanted/UI/Shared/Settings/Settings.swift
@@ -12,6 +12,7 @@ struct Settings: View {
     var languageModelStore = LanguageModelStore.shared
     var conversationStore = ConversationStore.shared
     var swiftDataService = SwiftDataService.shared
+    var fontConfigurationStore = FontConfigurationStore.shared
     
     @AppStorage("ollamaUri") private var ollamaUri: String = ""
     @AppStorage("systemPrompt") private var systemPrompt: String = ""
@@ -22,6 +23,7 @@ struct Settings: View {
     @AppStorage("appUserInitials") private var appUserInitials: String = ""
     @AppStorage("pingInterval") private var pingInterval: String = "5"
     @AppStorage("voiceIdentifier") private var voiceIdentifier: String = ""
+    @AppStorage("fontSizeCategory") private var fontSizeCategory: String = FontSizeCategory.medium.rawValue
     
     @StateObject private var speechSynthesiser = SpeechSynthesizer.shared
     
@@ -73,6 +75,7 @@ struct Settings: View {
             appUserInitials: $appUserInitials,
             pingInterval: $pingInterval,
             voiceIdentifier: $voiceIdentifier,
+            fontSizeCategory: $fontSizeCategory,
             save: save,
             checkServer: checkServer,
             deleteAll: deleteAll,
@@ -85,6 +88,11 @@ struct Settings: View {
         #endif
         .onChange(of: defaultOllamaModel) { _, modelName in
             languageModelStore.setModel(modelName: modelName)
+        }
+        .onChange(of: fontSizeCategory) { _, newCategory in
+            if let category = FontSizeCategory(rawValue: newCategory) {
+                fontConfigurationStore.updateFontSize(category: category)
+            }
         }
         .onAppear {
             /// refresh voices in the background

--- a/Enchanted/UI/Shared/Settings/SettingsView.swift
+++ b/Enchanted/UI/Shared/Settings/SettingsView.swift
@@ -19,6 +19,7 @@ struct SettingsView: View {
     @Binding var appUserInitials: String
     @Binding var pingInterval: String
     @Binding var voiceIdentifier: String
+    @Binding var fontSizeCategory: String
     @State var ollamaStatus: Bool?
     var save: () -> ()
     var checkServer: () -> ()
@@ -27,6 +28,7 @@ struct SettingsView: View {
     var voices: [AVSpeechSynthesisVoice]
     
     @State private var deleteConversationsDialog = false
+    @StateObject private var fontConfigurationStore = FontConfigurationStore.shared
     
     var body: some View {
         VStack {
@@ -36,7 +38,7 @@ struct SettingsView: View {
                         presentationMode.wrappedValue.dismiss()
                     } label: {
                         Text("Cancel")
-                            .font(.system(size: 16))
+                            .font(fontConfigurationStore.fontConfiguration.mediumUIFont())
                             .foregroundStyle(Color(.label))
                     }
                     
@@ -45,7 +47,7 @@ struct SettingsView: View {
                     
                     Button(action: save) {
                         Text("Save")
-                            .font(.system(size: 16))
+                            .font(fontConfigurationStore.fontConfiguration.mediumUIFont())
                             .foregroundStyle(Color(.label))
                     }
                 }
@@ -53,7 +55,7 @@ struct SettingsView: View {
                 HStack {
                     Spacer()
                     Text("Settings")
-                        .font(.system(size: 16))
+                        .font(fontConfigurationStore.fontConfiguration.mediumUIFont())
                         .fontWeight(.medium)
                         .foregroundStyle(Color(.label))
                     Spacer()
@@ -77,7 +79,7 @@ struct SettingsView: View {
                     VStack(alignment: .leading) {
                         Text("System prompt")
                         TextEditor(text: $systemPrompt)
-                            .font(.system(size: 13))
+                            .font(fontConfigurationStore.fontConfiguration.systemPromptFont())
                             .cornerRadius(4)
                             .multilineTextAlignment(.leading)
                             .frame(minHeight: 100)
@@ -128,6 +130,15 @@ struct SettingsView: View {
                         }
                     } label: {
                         Label("Appearance", systemImage: "sun.max")
+                            .foregroundStyle(Color.label)
+                    }
+                    
+                    Picker(selection: $fontSizeCategory) {
+                        ForEach(FontSizeCategory.allCases, id:\.self) { category in
+                            Text(category.displayName).tag(category.rawValue)
+                        }
+                    } label: {
+                        Label("Font Size", systemImage: "textformat.size")
                             .foregroundStyle(Color.label)
                     }
                     
@@ -209,6 +220,7 @@ struct SettingsView: View {
         appUserInitials: .constant("AM"),
         pingInterval: .constant("5"),
         voiceIdentifier: .constant("sample"),
+        fontSizeCategory: .constant(FontSizeCategory.medium.rawValue),
         save: {},
         checkServer: {},
         deleteAll: {},

--- a/Enchanted/UI/macOS/Chat/Components/InputFields_macOS.swift
+++ b/Enchanted/UI/macOS/Chat/Components/InputFields_macOS.swift
@@ -21,6 +21,7 @@ struct InputFieldsView: View {
     @State private var fileDropActive: Bool = false
     @State private var fileSelectingActive: Bool = false
     @FocusState private var isFocusedInput: Bool
+    @StateObject private var fontConfigurationStore = FontConfigurationStore.shared
     
     @MainActor private func sendMessage() {
         guard let selectedModel = selectedModel else { return }
@@ -71,7 +72,7 @@ struct InputFieldsView: View {
             ZStack(alignment: .trailing) {
                 TextField("Message", text: $message.animation(.easeOut(duration: 0.3)), axis: .vertical)
                     .focused($isFocusedInput)
-                    .font(.system(size: 14))
+                    .font(fontConfigurationStore.fontConfiguration.chatInputFont())
                     .frame(maxWidth:.infinity, minHeight: 40)
                     .clipped()
                     .textFieldStyle(.plain)


### PR DESCRIPTION
- Add FontConfiguration model with proportional scaling (XS to XL sizes)
- Create FontConfigurationStore with @AppStorage persistence
- Add font size picker to Settings UI with accessibility icon
- Update UI components to use configurable fonts while maintaining proportional relationships
- Modify markdown theme to support configurable base font size with relative (.em) scaling

Addresses font configuration accessibility feature request.